### PR TITLE
fix/feat: Fix ZisK build and update to rv64imacfdZicsr

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,6 @@ FORCE=1 ./run build sp1  # FORCE=1 rebuilds even if binary exists
 
 Each ZKVM's history page shows the exact commit, ISA, and results for every past run, as well as the particular test monitor commit, so the above workflow allows for reproducing historical results. 
 
-## Supported ZKVMs
-
-Currently testing:
-- **Airbender** - zkSync's zkVM
-- **Jolt** - a16z's lookup-based zkVM
-- **OpenVM** - Modular zkVM framework
-- **Pico** - Experimental zkVM
-- **r0vm** - RISC Zero's zkVM
-- **SP1** - Succinct Labs' zkVM
-- **Zisk** - Polygon's zkVM (RV64IMA)
-
 Configuration for each ZKVM is in `config.json`.
 
 ## Test Suites

--- a/riscof/plugins/zisk/env/model_test.h
+++ b/riscof/plugins/zisk/env/model_test.h
@@ -32,8 +32,7 @@
     addi t0, t0, 4;    \
     j next;   \
   end: \
-    li t1, 0xa0008f12; \
-    lw t0, (t1); \
+    csrr t0, 0xf12; \
     li   t1, ARCH_ID_ZISK; \
     beq t0, t1, zisk_exit; \
   qemu_exit: \

--- a/riscof/plugins/zisk/zisk_isa.yaml
+++ b/riscof/plugins/zisk/zisk_isa.yaml
@@ -1,11 +1,11 @@
 hart_ids: [0]
 hart0:
-  ISA: RV64IMA
+  ISA: RV64IMAFDCZicsr
   physical_addr_sz: 32
   User_Spec_Version: '2.3'
   supported_xlen: [64]
   misa:
-    reset-val: 0x80001101
+    reset-val: 0x8000112d
     rv64:
       accessible: true
       mxl:
@@ -23,7 +23,7 @@ hart0:
             warl:
                 dependency_fields: []
                 legal:
-                  - extensions[25:0] bitmask [0x0000000, 0x0001101]
+                  - extensions[25:0] bitmask [0x0000000, 0x000112d]
                 wr_illegal:
                   - Unchanged
     rv32:

--- a/src/debug.sh
+++ b/src/debug.sh
@@ -7,28 +7,28 @@ TEST_PATH=""
 SUITE="arch"
 
 while [[ $# -gt 0 ]]; do
-  case $1 in
-    --arch)
-      SUITE="arch"
-      shift
-      ;;
-    --extra)
-      SUITE="extra"
-      shift
-      ;;
-    *)
-      if [ -z "$ZKVM" ]; then
-        ZKVM="$1"
-      else
-        TEST_PATH="$1"
-      fi
-      shift
-      ;;
-  esac
+    case $1 in
+        --arch)
+            SUITE="arch"
+            shift
+            ;;
+        --extra)
+            SUITE="extra"
+            shift
+            ;;
+        *)
+            if [ -z "$ZKVM" ]; then
+                ZKVM="$1"
+            else
+                TEST_PATH="$1"
+            fi
+            shift
+            ;;
+    esac
 done
 
 if [ -z "$ZKVM" ] || [ -z "$TEST_PATH" ]; then
-  cat << EOF
+    cat << EOF
 Usage: ./run debug [--arch|--extra] <zkvm> <test-pattern>
 
 Examples:
@@ -39,48 +39,48 @@ Examples:
 This command re-runs a specific test with full verbose logging,
 bypassing RISCOF to help debug panics and failures.
 EOF
-  exit 1
+    exit 1
 fi
 
 # Check binary exists
 if [ ! -f "binaries/${ZKVM}-binary" ]; then
-  echo "❌ No binary found for $ZKVM at binaries/${ZKVM}-binary"
-  exit 1
+    echo "❌ No binary found for $ZKVM at binaries/${ZKVM}-binary"
+    exit 1
 fi
 
 # Check if test results exist
-if [ ! -d "test-results/${ZKVM}" ] || [ -z "$(find "test-results/${ZKVM}" -type d -path "*/dut" 2>/dev/null)" ]; then
-  echo "❌ No test results found for $ZKVM"
-  echo "   Run tests first: ./run test --${SUITE} $ZKVM"
-  exit 1
+if [ ! -d "test-results/${ZKVM}" ] || [ -z "$(find "test-results/${ZKVM}" -type d -path "*/dut" 2> /dev/null)" ]; then
+    echo "❌ No test results found for $ZKVM"
+    echo "   Run tests first: ./run test --${SUITE} $ZKVM"
+    exit 1
 fi
 
 # Find matching test ELF in results
 echo "🔍 Searching for test matching '$TEST_PATH' in ${SUITE} suite..."
 
 # Try exact match first (e.g., "add" matches "add-01" but not "addi-01")
-TEST_DIR=$(find "test-results/${ZKVM}" -type d -path "*/dut" -path "*/${TEST_PATH}-*" 2>/dev/null | head -1)
+TEST_DIR=$(find "test-results/${ZKVM}" -type d -path "*/dut" -path "*/${TEST_PATH}-*" 2> /dev/null | head -1)
 
 # Fall back to substring match if exact match fails
 if [ -z "$TEST_DIR" ]; then
-  TEST_DIR=$(find "test-results/${ZKVM}" -type d -path "*/dut" -path "*${TEST_PATH}*" 2>/dev/null | head -1)
+    TEST_DIR=$(find "test-results/${ZKVM}" -type d -path "*/dut" -path "*${TEST_PATH}*" 2> /dev/null | head -1)
 fi
 
 if [ -z "$TEST_DIR" ]; then
-  echo "❌ No test found matching '$TEST_PATH'"
-  echo ""
-  echo "Available tests (showing first 20):"
-  find "test-results/${ZKVM}" -type d -path "*/dut" 2>/dev/null | \
-    sed 's|test-results/'"${ZKVM}"'/||' | \
-    sed 's|/dut$||' | \
-    head -20
-  exit 1
+    echo "❌ No test found matching '$TEST_PATH'"
+    echo ""
+    echo "Available tests (showing first 20):"
+    find "test-results/${ZKVM}" -type d -path "*/dut" 2> /dev/null \
+        | sed 's|test-results/'"${ZKVM}"'/||' \
+        | sed 's|/dut$||' \
+        | head -20
+    exit 1
 fi
 
 TEST_ELF="${TEST_DIR}/my.elf"
 if [ ! -f "$TEST_ELF" ]; then
-  echo "❌ Test ELF not found at $TEST_ELF"
-  exit 1
+    echo "❌ Test ELF not found at $TEST_ELF"
+    exit 1
 fi
 
 # Extract test name with directory structure for unique log paths
@@ -108,22 +108,22 @@ ABS_LOG_FILE="$(realpath "$LOG_FILE")"
 
 # Run based on ZKVM type
 case "$ZKVM" in
-  openvm)
-    # OpenVM needs to run from a directory with Cargo.toml
-    # Extract the test directory (parent of dut/)
-    TEST_WORK_DIR="$(dirname "$(dirname "$TEST_ELF")")"
+    openvm)
+        # OpenVM needs to run from a directory with Cargo.toml
+        # Extract the test directory (parent of dut/)
+        TEST_WORK_DIR="$(dirname "$(dirname "$TEST_ELF")")"
 
-    # Create a temporary working directory we can write to
-    TEMP_WORK_DIR="${DEBUG_DIR}/temp_work"
-    mkdir -p "$TEMP_WORK_DIR"
+        # Create a temporary working directory we can write to
+        TEMP_WORK_DIR="${DEBUG_DIR}/temp_work"
+        mkdir -p "$TEMP_WORK_DIR"
 
-    # Copy the ELF and create necessary files
-    cp "$ABS_TEST_ELF" "$TEMP_WORK_DIR/my.elf"
+        # Copy the ELF and create necessary files
+        cp "$ABS_TEST_ELF" "$TEMP_WORK_DIR/my.elf"
 
-    cd "$TEMP_WORK_DIR"
+        cd "$TEMP_WORK_DIR"
 
-    # Create minimal Cargo.toml
-    cat > Cargo.toml << 'CARGO_TOML'
+        # Create minimal Cargo.toml
+        cat > Cargo.toml << 'CARGO_TOML'
 [package]
 name = "riscof-test"
 version = "0.1.0"
@@ -132,83 +132,83 @@ edition = "2021"
 [dependencies]
 CARGO_TOML
 
-    # Create minimal openvm.toml with required app_vm_config
-    cat > openvm.toml << 'OPENVM_TOML'
+        # Create minimal openvm.toml with required app_vm_config
+        cat > openvm.toml << 'OPENVM_TOML'
 app_vm_config = { exe = "my.elf" }
 OPENVM_TOML
 
-    RUST_LOG=debug RUST_BACKTRACE=full \
-      "$ABS_BINARY" openvm run \
-      --exe my.elf \
-      --signatures "${ABS_DEBUG_DIR}/debug.signature" \
-      2>&1 | tee "$ABS_LOG_FILE"
+        RUST_LOG=debug RUST_BACKTRACE=full \
+            "$ABS_BINARY" openvm run \
+            --exe my.elf \
+            --signatures "${ABS_DEBUG_DIR}/debug.signature" \
+            2>&1 | tee "$ABS_LOG_FILE"
 
-    EXIT_CODE=$?
-    cd - > /dev/null
-    ;;
+        EXIT_CODE=$?
+        cd - > /dev/null
+        ;;
 
-  sp1)
-    # Run SP1 with verbose output
-    RUST_LOG=debug RUST_BACKTRACE=full \
-      "binaries/${ZKVM}-binary" \
-      --elf "$TEST_ELF" \
-      2>&1 | tee "$LOG_FILE"
-    ;;
+    sp1)
+        # Run SP1 with verbose output
+        RUST_LOG=debug RUST_BACKTRACE=full \
+            "binaries/${ZKVM}-binary" \
+            --elf "$TEST_ELF" \
+            2>&1 | tee "$LOG_FILE"
+        ;;
 
-  jolt)
-    # Run Jolt with verbose output
-    RUST_LOG=debug RUST_BACKTRACE=full \
-      "binaries/${ZKVM}-binary" \
-      "$TEST_ELF" \
-      2>&1 | tee "$LOG_FILE"
-    ;;
+    jolt)
+        # Run Jolt with verbose output
+        RUST_LOG=debug RUST_BACKTRACE=full \
+            "binaries/${ZKVM}-binary" \
+            "$TEST_ELF" \
+            2>&1 | tee "$LOG_FILE"
+        ;;
 
-  r0vm)
-    # Run r0vm with verbose output
-    RUST_LOG=debug RUST_BACKTRACE=full \
-      "binaries/${ZKVM}-binary" \
-      "$TEST_ELF" \
-      2>&1 | tee "$LOG_FILE"
-    ;;
+    r0vm)
+        # Run r0vm with verbose output
+        RUST_LOG=debug RUST_BACKTRACE=full \
+            "binaries/${ZKVM}-binary" \
+            "$TEST_ELF" \
+            2>&1 | tee "$LOG_FILE"
+        ;;
 
-  zisk)
-    # Run zisk with verbose output
-    RUST_LOG=debug RUST_BACKTRACE=full \
-      "binaries/${ZKVM}-binary" \
-      "$TEST_ELF" \
-      2>&1 | tee "$LOG_FILE"
-    ;;
+    zisk)
+        # Run zisk with verbose output
+        RUST_LOG=debug RUST_BACKTRACE=full \
+            "binaries/${ZKVM}-binary" \
+            -e "$TEST_ELF" \
+            2>&1 | tee "$LOG_FILE"
+        ;;
 
-  pico)
-    # Run pico with verbose output
-    RUST_LOG=debug RUST_BACKTRACE=full \
-      "binaries/${ZKVM}-binary" \
-      "$TEST_ELF" \
-      2>&1 | tee "$LOG_FILE"
-    ;;
+    pico)
+        # Run pico with verbose output
+        RUST_LOG=debug RUST_BACKTRACE=full \
+            "binaries/${ZKVM}-binary" \
+            "$TEST_ELF" \
+            2>&1 | tee "$LOG_FILE"
+        ;;
 
-  airbender)
-    # Run airbender with verbose output
-    RUST_LOG=debug RUST_BACKTRACE=full \
-      "binaries/${ZKVM}-binary" \
-      "$TEST_ELF" \
-      2>&1 | tee "$LOG_FILE"
-    ;;
+    airbender)
+        # Run airbender with verbose output
+        RUST_LOG=debug RUST_BACKTRACE=full \
+            "binaries/${ZKVM}-binary" \
+            "$TEST_ELF" \
+            2>&1 | tee "$LOG_FILE"
+        ;;
 
-  *)
-    echo "❌ Unknown ZKVM: $ZKVM"
-    echo "   Supported: openvm, sp1, jolt, r0vm, zisk, pico, airbender"
-    exit 1
-    ;;
+    *)
+        echo "❌ Unknown ZKVM: $ZKVM"
+        echo "   Supported: openvm, sp1, jolt, r0vm, zisk, pico, airbender"
+        exit 1
+        ;;
 esac
 
 EXIT_CODE=$?
 
 echo ""
 if [ $EXIT_CODE -eq 0 ]; then
-  echo "✅ Test completed successfully"
+    echo "✅ Test completed successfully"
 else
-  echo "❌ Test failed with exit code: $EXIT_CODE"
+    echo "❌ Test failed with exit code: $EXIT_CODE"
 fi
 
 echo ""
@@ -216,21 +216,21 @@ echo "📝 Full log saved to: $LOG_FILE"
 
 # Save signature to output folder if it exists
 if [ -f "${DEBUG_DIR}/debug.signature" ]; then
-  echo ""
-  echo "📄 Signature saved to: ${DEBUG_DIR}/debug.signature"
+    echo ""
+    echo "📄 Signature saved to: ${DEBUG_DIR}/debug.signature"
 fi
 
 # Compare with expected if available
 EXPECTED_SIG="${TEST_DIR}/../ref/Reference-sail_cSim.signature"
 if [ -f "$EXPECTED_SIG" ]; then
-  if [ -f "${DEBUG_DIR}/debug.signature" ]; then
-    echo ""
-    if diff -q "${DEBUG_DIR}/debug.signature" "$EXPECTED_SIG" > /dev/null; then
-      echo "✅ Signatures match!"
-    else
-      echo "❌ Signatures differ (see ${DEBUG_DIR}/debug.signature and ${EXPECTED_SIG})"
+    if [ -f "${DEBUG_DIR}/debug.signature" ]; then
+        echo ""
+        if diff -q "${DEBUG_DIR}/debug.signature" "$EXPECTED_SIG" > /dev/null; then
+            echo "✅ Signatures match!"
+        else
+            echo "❌ Signatures differ (see ${DEBUG_DIR}/debug.signature and ${EXPECTED_SIG})"
+        fi
     fi
-  fi
 fi
 
 exit $EXIT_CODE


### PR DESCRIPTION
Need to supply a flag to the CLI now. The update from ZisK adds floating point support :tada: and the test monitor will show that indeed all F and D tests are passing. As one can see [in the spec](https://github.com/riscv/riscv-isa-manual/blob/22928969d6df9ab2278d82670017960a9741f79e/src/naming.adoc?plain=1#L43),  the F spec requires the Zicsr spec, and indeed this is enforced by RISCOF, so we update the ISA of ZisK in our model to the minimal valid ISA containing the supported extensions, namely rv64imacfdZicsr. It was not the intention of ZisK to fully support Zicsr, and we see there are some gaps.

Note that ZisK is very close to supporting rv64gc. The same link above shows that the difference is: full support for Zicsr and Zifencei.