### PR TITLE
LambdaVM: fix branch test failures on ACT4 4.0.0 (linker SUBALIGN)

### DIFF
--- a/act4-configs/lambdavm/lambdavm-rv64im-zicclsm/link.ld
+++ b/act4-configs/lambdavm/lambdavm-rv64im-zicclsm/link.ld
@@ -1,16 +1,18 @@
 OUTPUT_ARCH( "riscv" )
 ENTRY(rvtest_entry_point)
 
+/* SUBALIGN(4): override 4096-byte input section alignments from the 4.0.0 tests.
+   Without this, the linker inserts a ~4KB zero-filled gap between .text.init and
+   .text.rvtest; LambdaVM scans all bytes in the executable PT_LOAD segment at
+   load time and panics on 0x00000000 (UnknownOpcode) in the gap. */
 SECTIONS
 {
   . = 0x80000000;
-  .text.init : { *(.text.init) }
-  .text : { *(.text) }
+  .text : SUBALIGN(4) { *(.text.init) *(.text) *(.text.*) }
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }
   . = ALIGN(0x1000);
-  .data : { *(.data) }
-  .data.string : { *(.data.string) }
+  .data : { *(.data) *(.data.*) *(.data.string) }
   . = ALIGN(0x1000);
   .bss : { *(.bss) }
   _end = .;

--- a/act4-configs/lambdavm/lambdavm-rv64im/link.ld
+++ b/act4-configs/lambdavm/lambdavm-rv64im/link.ld
@@ -1,16 +1,18 @@
 OUTPUT_ARCH( "riscv" )
 ENTRY(rvtest_entry_point)
 
+/* SUBALIGN(4): override 4096-byte input section alignments from the 4.0.0 tests.
+   Without this, the linker inserts a ~4KB zero-filled gap between .text.init and
+   .text.rvtest; LambdaVM scans all bytes in the executable PT_LOAD segment at
+   load time and panics on 0x00000000 (UnknownOpcode) in the gap. */
 SECTIONS
 {
   . = 0x80000000;
-  .text.init : { *(.text.init) }
-  .text : { *(.text) }
+  .text : SUBALIGN(4) { *(.text.init) *(.text) *(.text.*) }
   . = ALIGN(0x1000);
   .tohost : { *(.tohost) }
   . = ALIGN(0x1000);
-  .data : { *(.data) }
-  .data.string : { *(.data.string) }
+  .data : { *(.data) *(.data.*) *(.data.string) }
   . = ALIGN(0x1000);
   .bss : { *(.bss) }
   _end = .;

--- a/data/history/lambdavm-act4-full.json
+++ b/data/history/lambdavm-act4-full.json
@@ -155,9 +155,9 @@
       "has_proving": false
     },
     {
-      "date": "2026-06-13T15:10:18Z",
+      "date": "2026-06-16T18:48:04Z",
       "commit": "09ef37d9",
-      "monitor_commit": "3872cde5",
+      "monitor_commit": "84edd9b8",
       "act4_commit": "a7c99303516f4e668f7488f172043392e23b9dfd",
       "act4_version": "4.0.0",
       "isa": "RV64IM_Zicclsm",
@@ -170,6 +170,12 @@
         "I-and-00",
         "I-andi-00",
         "I-auipc-00",
+        "I-beq-00",
+        "I-bge-00",
+        "I-bgeu-00",
+        "I-blt-00",
+        "I-bltu-00",
+        "I-bne-00",
         "I-fence-00",
         "I-jal-00",
         "I-jalr-00",
@@ -230,17 +236,11 @@
         "Misalign-sh-00",
         "Misalign-sw-00"
       ],
-      "failed": [
-        "I-beq-00",
-        "I-bge-00",
-        "I-bgeu-00",
-        "I-blt-00",
-        "I-bltu-00",
-        "I-bne-00"
-      ],
+      "failed": [],
       "prove_failed": [],
       "verify_failed": [],
-      "has_proving": false
+      "has_proving": false,
+      "notes": "Replaced 2026-06-13 run (66/72): branch test failures were caused by missing SUBALIGN(4) in link.ld, which left a zero-filled inter-section gap in the executable segment that LambdaVM\u2019s instruction scanner hit at load time. Fixed in test configuration."
     }
   ]
 }

--- a/data/history/lambdavm-act4-standard.json
+++ b/data/history/lambdavm-act4-standard.json
@@ -173,9 +173,9 @@
       "has_proving": true
     },
     {
-      "date": "2026-06-13T15:10:18Z",
+      "date": "2026-06-16T18:48:04Z",
       "commit": "09ef37d9",
-      "monitor_commit": "3872cde5",
+      "monitor_commit": "84edd9b8",
       "act4_commit": "a7c99303516f4e668f7488f172043392e23b9dfd",
       "act4_version": "4.0.0",
       "isa": "RV64IM_Zicclsm",
@@ -188,6 +188,12 @@
         "I-and-00",
         "I-andi-00",
         "I-auipc-00",
+        "I-beq-00",
+        "I-bge-00",
+        "I-bgeu-00",
+        "I-blt-00",
+        "I-bltu-00",
+        "I-bne-00",
         "I-fence-00",
         "I-jal-00",
         "I-jalr-00",
@@ -248,17 +254,11 @@
         "Misalign-sh-00",
         "Misalign-sw-00"
       ],
-      "failed": [
-        "I-beq-00",
-        "I-bge-00",
-        "I-bgeu-00",
-        "I-blt-00",
-        "I-bltu-00",
-        "I-bne-00"
-      ],
+      "failed": [],
       "prove_failed": [],
       "verify_failed": [],
-      "has_proving": true
+      "has_proving": true,
+      "notes": "Replaced 2026-06-13 run (66/72): branch test failures were caused by missing SUBALIGN(4) in link.ld, which left a zero-filled inter-section gap in the executable segment that LambdaVM\u2019s instruction scanner hit at load time. Fixed in test configuration."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- All 6 branch tests (I-beq/bge/bgeu/blt/bltu/bne-00) failed for LambdaVM after upgrading to ACT4 4.0.0
- Root cause: ACT4 4.0.0 splits test code into \`.text.init\` (32 bytes) and \`.text.rvtest\` (page-aligned), creating a ~4KB zero-filled gap between them in the executable PT_LOAD segment; LambdaVM's \`InstructionCache::new\` scans the entire segment at load time and panics with \`UnknownOpcode(0)\` on the gap
- Fix: add \`SUBALIGN(4)\` to both \`lambdavm-rv64im\` and \`lambdavm-rv64im-zicclsm\` linker scripts, collapsing all \`.text.*\` sections into a contiguous block — the same pattern already used by SP1 and OpenVM configs
- Result: 72/72 native execute, 72/72 target prove+verify (up from 66/72)
- The 2026-06-13 run history entry (66/72) is replaced; the run's \`notes\` field records the cause

## Test plan

- [x] \`FORCE=1 ./run test lambdavm\` — 72/72 native, 72/72 target prove+verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)