### PR TITLE
zisk: fix I-auipc-00 prove failure via linker SUBALIGN(4)

### DIFF
--- a/act4-configs/zisk/zisk-rv64im-zicclsm/link.ld
+++ b/act4-configs/zisk/zisk-rv64im-zicclsm/link.ld
@@ -1,12 +1,15 @@
 OUTPUT_ARCH( "riscv" )
 ENTRY(rvtest_entry_point)
 
+/* SUBALIGN(4): override 4096-byte input section alignments from the 4.0.0 tests.
+   Without this, the linker inserts a ~4KB zero-filled gap between .text.init and
+   .text.rvtest; while Zisk uses section-based ROM loading (so the gap isn't in the
+   ROM), AUIPC instructions then run at PC 0x80001xxx and the Zisk prover fails
+   VerifyGlobalConstraints — indicating a circuit bug with AUIPC at higher PCs. */
 SECTIONS
 {
   . = 0x80000000;
-  .text.init : { *(.text.init) }
-  . = ALIGN(0x1000);
-  .text : { *(.text) }
+  .text : SUBALIGN(4) { *(.text.init) *(.text) *(.text.*) }
   .rodata : { *(.rodata .rodata.*)}
   . = 0xa0010000;
   . = ALIGN(0x1000);

--- a/act4-configs/zisk/zisk-rv64im/link.ld
+++ b/act4-configs/zisk/zisk-rv64im/link.ld
@@ -1,12 +1,15 @@
 OUTPUT_ARCH( "riscv" )
 ENTRY(rvtest_entry_point)
 
+/* SUBALIGN(4): override 4096-byte input section alignments from the 4.0.0 tests.
+   Without this, the linker inserts a ~4KB zero-filled gap between .text.init and
+   .text.rvtest; while Zisk uses section-based ROM loading (so the gap isn't in the
+   ROM), AUIPC instructions then run at PC 0x80001xxx and the Zisk prover fails
+   VerifyGlobalConstraints — indicating a circuit bug with AUIPC at higher PCs. */
 SECTIONS
 {
   . = 0x80000000;
-  .text.init : { *(.text.init) }
-  . = ALIGN(0x1000);
-  .text : { *(.text) }
+  .text : SUBALIGN(4) { *(.text.init) *(.text) *(.text.*) }
   .rodata : { *(.rodata .rodata.*)}
   . = 0xa0010000;
   . = ALIGN(0x1000);


### PR DESCRIPTION
## Summary

- ACT4 4.0.0 restructures ELF layout: separate `.text.init` / `.text.rvtest` / `.text.rvmodel` sections. The Zisk linker script only listed `.text.init` and `.text` explicitly, so the new sections became orphans placed after a `. = ALIGN(0x1000)` boundary — shifting all code to the 0x80001xxx range.
- Execution passes at any PC. But the Zisk prover fails at `VerifyGlobalConstraints` / `VadcopFinal` when AUIPC instructions run at PC 0x80001xxx. Zisk uses section-based ROM loading (the ~4KB gap of zeros between sections isn't in the ROM); the failure is triggered by the shifted PC range itself, pointing to a Zisk circuit bug with AUIPC when bit 12 of PC is set.
- Fix: `SUBALIGN(4)` in both Zisk linker scripts (matching SP1, OpenVM, LambdaVM). This collapses all `.text.*` sections into a contiguous block at 0x80000000, keeping code in the 0x80000xxx range as in pre-4.0.0 tests.

## Test plan

- [x] `I-auipc-00` prove+verify passes with SUBALIGN layout (was: `VerifyGlobalConstraints` assertion failure)
- [x] `71/72` execute-only passes (I-fence-00 expected failure, unchanged)
- [ ] Full prove suite (72 target ELFs) — recommended before merging if CI runs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)