### PR TITLE
zkvm.html: show test-monitor commit in ACT4 column instead of a dash

### DIFF
--- a/docs/zkvm.html
+++ b/docs/zkvm.html
@@ -286,9 +286,21 @@
                 const actRun = g.runs[0];
                 const actLabel = act4Label(actRun);
                 const actUrl = act4Url(actRun);
-                const act4Html = actLabel
-                    ? (actUrl ? `<a href="${actUrl}" class="commit-link" onclick="event.stopPropagation()">${actLabel}</a>` : `<span class="commit-link">${actLabel}</span>`)
-                    : '<span class="none">&mdash;</span>';
+                const monitorCommit = actRun?.monitor_commit;
+                let act4Html;
+                if (actLabel) {
+                    act4Html = actUrl
+                        ? `<a href="${actUrl}" class="commit-link" onclick="event.stopPropagation()">${actLabel}</a>`
+                        : `<span class="commit-link">${actLabel}</span>`;
+                } else if (monitorCommit && monitorCommit !== 'unknown') {
+                    // ACT4 version wasn't recorded for this run, and the arch-test version
+                    // it used wasn't a tagged release. Link the test-monitor commit that
+                    // produced the run instead — config.json at that commit pins the exact
+                    // arch-test commit, so the version is still recoverable.
+                    act4Html = `<a href="https://github.com/eth-act/zkevm-test-monitor/commit/${monitorCommit}" class="commit-link" title="Test monitor commit (ACT4 version not recorded for this run)" onclick="event.stopPropagation()">${commitShort(monitorCommit)}</a>`;
+                } else {
+                    act4Html = '<span class="none">&mdash;</span>';
+                }
 
                 const firstRow = first.replace('<tr', `<tr`).replace(
                     /<td>.*?<\/td>/,


### PR DESCRIPTION
## Summary

The per-VM run-history table (`docs/zkvm.html`) gained an **ACT4** column in #20. It shows `v4.0.0` for runs that recorded `act4_version`, but a bare **—** for every pre-4.0.0 run, since those runs used an *untagged* arch-test commit with no clean version label.

This fills those dashes with the run's **test-monitor commit** (`monitor_commit`, already present on every run), linked to the `eth-act/zkevm-test-monitor` commit that produced the run. `config.json` at that commit pins the exact arch-test commit, so the version is still fully recoverable from the link. The **—** now appears only if a run has no `monitor_commit` at all.

A `title` tooltip on the link clarifies it's the test-monitor commit (ACT4 version not recorded for that run).

## Scope

- Single file: `docs/zkvm.html` (15 insertions, 3 deletions) — view-only/rendering change. No data files touched.

## Verification

Served `docs/` locally and loaded the SP1 page (most dash rows). The three previously-blank ACT4 cells now render `283ec44d`, `5408b6c4`, `73150890`, each linking to the corresponding `eth-act/zkevm-test-monitor` commit; the 4.0.0 run still shows `v4.0.0` linked to the arch-test release. Only console message is a pre-existing favicon 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)