### PR TITLE
index.html: 'Full ISA' column + 'Standard ISA Tests' header

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -204,8 +204,8 @@
                         <tr>
                             <th rowspan="2">ZKVM</th>
                             <th rowspan="2">Commit</th>
-                            <th rowspan="2">ISA</th>
-                            <th colspan="3" class="col-group col-group-target"><a href="https://github.com/eth-act/zkvm-standards/blob/main/standards/riscv-target/target.md">Standard ISA &#x1F517;</a></th>
+                            <th rowspan="2">Full ISA</th>
+                            <th colspan="3" class="col-group col-group-target"><a href="https://github.com/eth-act/zkvm-standards/blob/main/standards/riscv-target/target.md">Standard ISA &#x1F517;</a> Tests</th>
                             <th rowspan="2">Last Run</th>
                         </tr>
                         <tr>


### PR DESCRIPTION
Two home-page header tweaks:

- The leftmost **ISA** column (each VM's native ISA) is now labeled **Full ISA**, contrasting with the standardized target subset.
- The **Standard ISA** column-group header now reads **Standard ISA Tests** (the "Tests" word appended after the existing link).

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)